### PR TITLE
emit `header` event

### DIFF
--- a/write.js
+++ b/write.js
@@ -40,6 +40,7 @@ NamedWriteStream.prototype._preprocess = function(data, callback) {
   if (! this.metadata) {
     try {
       this.metadata = JSON.parse(data.toString());
+      this.emit('header', this.metadata);
       return callback();
     }
     catch (e) {


### PR DESCRIPTION
It can be useful to have the headers file metadata before the file is received completely. Eg. for progress bars or to display the name while still receiving the file.
